### PR TITLE
fix: Fix .mjs extension removal

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -90,7 +90,7 @@ install_version() {
 			# echo "File -> $f"
 			# ln -sf $(echo $f |sed -e 's/.mjs//') $f
 			# mv "$f" "$(echo "$f" | sed -e 's/.mjs//')"
-			mv "$f" "${f//.mjs/''/}"
+			mv "$f" "${f%.mjs}"
 		done
 
 		# debug


### PR DESCRIPTION
This fixes an installation error with mise (possibly affects asdf as well?):

`mv: cannot move '.local/share/mise/installs/ni/0.21.12/bin/na.mjs' to '.local/share/mise/installs/ni/0.21.12/bin/na/': Not a directory`

Mise is intended as a drop-in replacement for asdf, but installing ni fails while trying to remove the `.mjs` extension.  I would imagine asdf fails as well but I don't have that installed anymore.

This fix worked for me, so I thought I'd contribute it back